### PR TITLE
fix(scrape): point at palottery.pa.gov instead of redirecting host

### DIFF
--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -12,7 +12,9 @@ import (
 	"golang.org/x/net/html"
 )
 
-const webpageFormat = "https://www.palottery.state.pa.us/Games/Print-Past-Winning-Numbers.aspx?id=28&year=%d&print=1"
+// The PA Lottery moved from palottery.state.pa.us (now a 301 redirect) to
+// palottery.pa.gov. Point directly at the canonical host to avoid the redirect.
+const webpageFormat = "https://www.palottery.pa.gov/Games/Print-Past-Winning-Numbers.aspx?id=28&year=%d&print=1"
 
 func getFakeNums() (map[time.Time]int, []time.Time) {
 	nyd := time.Date(time.Now().Year(), 1, 1, 0, 0, 0, 0, time.Local)


### PR DESCRIPTION
## What
Update the scraper URL from `palottery.state.pa.us` to `palottery.pa.gov`.

## Why
The old host now returns a **301 redirect** to `palottery.pa.gov`:
```
$ curl -s -o /dev/null -w '%{http_code}' \
  'https://www.palottery.state.pa.us/Games/Print-Past-Winning-Numbers.aspx?id=28&year=2026&print=1'
301
```
Go's `http.Get` follows redirects so the scraper still works *today*, but relying on the state keeping that redirect alive is fragile. Pointing at the canonical host removes the dependency.

## Verification
`go run . dump` (live, real data) returns the full current year against the new host, with holidays correctly computed (e.g. Juneteenth 2026 → \$50). `go vet ./...` clean.

## Note
Data is available on this host back to **1977** — useful for the future "winners across all years" idea, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)